### PR TITLE
Use .then async procedure to set balance

### DIFF
--- a/lib/wallet/home_screen.dart
+++ b/lib/wallet/home_screen.dart
@@ -172,9 +172,18 @@ Widget getGeneratedWidget(XRPLWallet wallet) {
       Center(
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 25.0),
-          child: ValueListenableBuilder<String>(
+          child: ValueListenableBuilder<String?>(
               valueListenable: wallet.balance,
-              builder: (BuildContext context, String balance, Widget? _) {
+              builder: (BuildContext context, String? balance, Widget? _) {
+                if (balance == null) {
+                  return Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text("Loading balance: ",
+                            style: TextStyle(fontSize: 25)),
+                        CircularProgressIndicator()
+                      ]);
+                }
                 return SelectableText('Your balance: $balance',
                     style: const TextStyle(fontSize: 25));
               }),

--- a/lib/wallet/xrpl_wallet.dart
+++ b/lib/wallet/xrpl_wallet.dart
@@ -52,7 +52,7 @@ class XRPLWallet {
 
   Wallet? _wallet;
 
-  ValueNotifier<String> balance = ValueNotifier("Unavailable");
+  ValueNotifier<String?> balance = ValueNotifier(null);
 
   XRPLWallet(String seed, {bool testMode = false}) {
     _netUrl = testMode ? testNetUrl : mainnetUrl;

--- a/lib/wallet/xrpl_wallet.dart
+++ b/lib/wallet/xrpl_wallet.dart
@@ -44,7 +44,8 @@ class InvalidPaymentChannelException implements Exception {
 
 class XRPLWallet {
   static String uninitialisedUrl = 'NOT INITIALISED!';
-  static String testNetUrl = 'wss://s.altnet.rippletest.net:51233';
+  // Choose from https://xrpl.org/public-servers.html
+  static String testNetUrl = 'wss://s.altnet.rippletest.net/';
   // TODO: change once prod-ready:
   static String mainnetUrl = 'NOT IMPLEMENTED YET';
 
@@ -71,18 +72,20 @@ class XRPLWallet {
     }
 
     try {
-      client.connect().then((erg) {
-        client.fundWallet(_wallet); // TODO: Remove this in the future
-        String address = _wallet!.address;
-        client.getXrpBalance(address).then((balanceString) {
-          balance.value = balanceString.toString();
+      promiseToFuture(client.connect()).then((erg) {
+        // TODO: Remove this in the future
+        promiseToFuture(client.fundWallet(_wallet)).then((e) {
+          String address = _wallet!.address;
+          promiseToFuture(client.getXrpBalance(address)).then((balanceString) {
+            balance.value = balanceString.toString();
+          }).whenComplete(() {
+            client.disconnect();
+          });
         });
       });
     } catch (e, stacktrace) {
-      logger.e('Exception caught: {e}');
+      logger.e('Exception caught: ${e.toString()}');
       logger.e(stacktrace);
-    } finally {
-      client.disconnect();
     }
   }
 

--- a/test/image_deployment_demo_test.mocks.dart
+++ b/test/image_deployment_demo_test.mocks.dart
@@ -210,15 +210,15 @@ class MockXRPLWallet extends _i1.Mock implements _i5.XRPLWallet {
   }
 
   @override
-  _i4.ValueNotifier<String> get balance => (super.noSuchMethod(
+  _i4.ValueNotifier<String?> get balance => (super.noSuchMethod(
         Invocation.getter(#balance),
-        returnValue: _FakeValueNotifier_3<String>(
+        returnValue: _FakeValueNotifier_3<String?>(
           this,
           Invocation.getter(#balance),
         ),
-      ) as _i4.ValueNotifier<String>);
+      ) as _i4.ValueNotifier<String?>);
   @override
-  set balance(_i4.ValueNotifier<String>? _balance) => super.noSuchMethod(
+  set balance(_i4.ValueNotifier<String?>? _balance) => super.noSuchMethod(
         Invocation.setter(
           #balance,
           _balance,


### PR DESCRIPTION
## What does this PR do

* Uses an extra `.then` in the wallet funding procedure
* Displays spinner when balances are unavailable

## How should this PR be tested?

* Spin up the client locally and via the deployed PR link
* Instantiate a new wallet and ensure it displays the balance

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
