### PR TITLE
Re enable analytics

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,29 +4,18 @@
   <script
     type="text/javascript"
     src="https://app.termly.io/embed.min.js"
-    data-auto-block="off"
+    data-auto-block="on"
     data-website-uuid="1b1475d2-3c77-4545-b5fc-785d862fd817"
   ></script>
   <!-- Google Tag Manager -->
-  <!--
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-KMZJNJH');</script>
-  -->
-  <!-- End Google Tag Manager -->
-  <!-- Google Analytics -->
-  <!--
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-Z5J90FJ19J"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', '6TPZFK7NQ6');
+    gtag('config', 'G-6TPZFK7NQ6');
   </script>
-  -->
-  <!-- End Google Analytics -->
+  <!-- End Google Tag Manager -->
   <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
@@ -80,15 +69,6 @@
         }
       });
     });
-    //window.addEventListener('scroll', function() {
-    //  clearTimeout(window.scrollTimer);
-    //  window.scrollTimer = setTimeout(function() {
-    //    gtag('event', 'scroll', {
-    //      'event_category': 'Page Interaction',
-    //      'event_label': 'Page Scrolled'
-    //    });
-    //  }, 100);
-    //});
   </script>
   <script src="https://unpkg.com/xrpl@2.6.0/build/xrpl-latest-min.js"></script>
 </body>

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <firebase_core/firebase_core_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FirebaseCorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  firebase_core
   url_launcher_windows
 )
 


### PR DESCRIPTION
## What does this PR do
* Re-enables/fixes gtags on our different pages, so that if cookies are declined (or the analytics ones are disabled) they do not get set.
* Updates some flutter build artifacts

## How should this PR be tested?
* Open the generated firebase link in a private browser window with all privacy extensions disabled and an empty cache/local storage, and:
- [x] Confirm that you can see the cookie banner
- [x] shift+ctrl+I and view your cookies - there should be no cookies yet!
- [x] decline cookies, there should still be none
- [x] Close the private browser window (and all others), create a fresh one and go back to the generated firebase link, and this time click "preferences" and disable the analytics cookies.  You should still see no cookies in your shift+ctrl+I panel.
- [x] Repeat the step above, but accept cookies this time.  You should see that the cookies have been set.  Depending on the browser and privacy extensions, you might also see something in Google Analytics.

## Checklist before requesting a review
- [x] I have performed a self-review of my code