### PR TITLE
Revert "Add url path strategy to remove training hash"

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,8 +14,6 @@ import 'package:dhali/config.dart' show Config;
 import 'package:dhali/marketplace/asset_page.dart';
 import 'package:dhali/marketplace/model/marketplace_list_data.dart';
 
-import 'package:url_strategy/url_strategy.dart';
-
 Future<void> initializeApp() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(
@@ -37,7 +35,6 @@ MultipartRequest Function(String method, String path) getRequestFunction =
 
 void main() async {
   await initializeApp();
-  setPathUrlStrategy();
   runApp(MyApp(getRequest: getRequestFunction));
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,6 @@ dependencies:
     bip39: ^1.0.6
     uuid: ^3.0.7
     split_view: ^3.2.1
-    url_strategy: ^0.2.0
     dhali_wallet:
       git:
         url: "https://github.com/Dhali-org/Dhali-wallet.git"


### PR DESCRIPTION
This reverts commit b92aa2e6103032f067b24b3654a7dffb404517b3.

## What does this PR do

* This PR reverts a commit so that URLs to assets will work
* This original commit was done to remove the auto-appended "/#/" from URLs
* It is important to understand fully how this reversion interacts with:
    - query strings
    - the experiments we're running in Google Optimize

## How should this PR be tested?

* Navigate to an asset and try reloading the page
* Pass all combinations of the query strings
* Ensure that the URLs are compatible with the URLs we have entered into Google Optimize

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
