### PR TITLE
Tweak not implemented widget

### DIFF
--- a/lib/navigation_home_screen.dart
+++ b/lib/navigation_home_screen.dart
@@ -229,7 +229,8 @@ class _NavigationHomeScreenState extends State<NavigationHomeScreen> {
                   : () {
                       showNotImplentedWidget(
                           context: context,
-                          feature: "Mobile asset administration");
+                          feature: "Mobile asset administration",
+                          message: "This tab is available on desktops.");
                     },
             ),
             ListTile(

--- a/lib/utils/not_implemented_dialog.dart
+++ b/lib/utils/not_implemented_dialog.dart
@@ -13,12 +13,12 @@ void showNotImplentedWidget(
             parameters: {"feature": feature});
         const String contentStart = "This is not your fault!";
         return AlertDialog(
-          title: const Text(
-            "This feature has not been implemented yet.",
-          ),
-          content: message == null
-              ? Text(contentStart)
-              : Text("$contentStart \n$message"),
-        );
+            title: const Text(
+              "This feature has not been implemented yet.",
+              textAlign: TextAlign.center,
+            ),
+            content: Text(
+                message == null ? contentStart : "$contentStart\n$message",
+                textAlign: TextAlign.center));
       });
 }

--- a/lib/utils/not_implemented_dialog.dart
+++ b/lib/utils/not_implemented_dialog.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:dhali/analytics/analytics.dart';
 
-void showNotImplentedWidget({required BuildContext context, String? feature}) {
+void showNotImplentedWidget(
+    {required BuildContext context, String? feature, String? message}) {
   showDialog(
       context: context,
       builder: (BuildContext _) {
@@ -10,9 +11,14 @@ void showNotImplentedWidget({required BuildContext context, String? feature}) {
             command: "event",
             target: "NotImplementedShown",
             parameters: {"feature": feature});
-        return const AlertDialog(
-          title: Text("This feature has not been implemented yet"),
-          content: Text("This is not your fault!"),
+        const String contentStart = "This is not your fault!";
+        return AlertDialog(
+          title: const Text(
+            "This feature has not been implemented yet",
+          ),
+          content: message == null
+              ? Text(contentStart)
+              : Text("$contentStart \n$message"),
         );
       });
 }

--- a/lib/utils/not_implemented_dialog.dart
+++ b/lib/utils/not_implemented_dialog.dart
@@ -14,7 +14,7 @@ void showNotImplentedWidget(
         const String contentStart = "This is not your fault!";
         return AlertDialog(
           title: const Text(
-            "This feature has not been implemented yet",
+            "This feature has not been implemented yet.",
           ),
           content: message == null
               ? Text(contentStart)

--- a/web/index.html
+++ b/web/index.html
@@ -2,9 +2,9 @@
 <html>
 
 <head>
-  <script src="https://www.googleoptimize.com/optimize.js?id=OPT-58JTSVD"></script>
   <script type="text/javascript" src="https://app.termly.io/embed.min.js" data-auto-block="off"
     data-website-uuid="1b1475d2-3c77-4545-b5fc-785d862fd817"></script>
+  <script src="https://www.googleoptimize.com/optimize.js?id=OPT-58JTSVD"></script>
   <!-- GTM_HEAD -->
   <!--
     If you are serving your web app in a path other than the root, change the


### PR DESCRIPTION
## What does this PR do
* Makes a few tweaks to `showNotImplementedWidget`, to make things clearer for asset creation journeys on mobile devices

## How should this PR be tested?
- [ ] Manually inspect the proposed change, and confirm that you agree with them
- [ ] Try running the preview app on the preview link, and confirm that you agree with the new error message that comes up

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
